### PR TITLE
Always run os_image_facts

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,7 @@
 - name: idr vm | get image
   os_image_facts:
     image: "{{ idr_vm_image }}"
+  always_run: yes
   # Creates variable openstack_image
 
 - name: idr vm | check image


### PR DESCRIPTION
This allows the role to be successfully run in check-mode when there are no changes.

Without this the `openstack_image` variable isn't populated, so all comparisons fail.