### PR TITLE
Omero readonly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
 
 install:
   # Install ansible
-  - pip install ansible
+  - pip install ome-ansible-molecule-dependencies
 
   # Check ansible version
   - ansible --version
@@ -24,6 +24,7 @@ install:
 script:
   # Basic role syntax check
   - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+  - ansible-lint tests/test.yml
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/README.md
+++ b/README.md
@@ -26,8 +26,14 @@ Optional variables:
 Booleans indicating the purpose of this server:
 - If any of these are `True` they will be used to automatically set the security groups and host-groups for this VM, default `False`. Multiple may be set to `True` if a server has multiple purposes.
   - `idr_vm_database`: An IDR database server
-  - `idr_vm_omero`: An IDR OMERO server
+  - `idr_vm_omeroreadwrite`: An IDR OMERO read-write server
+  - `idr_vm_omeroreadonly`: An IDR OMERO read-only server
   - `idr_vm_proxy`: An IDR web proxy server
+  - `idr_vm_dockermanager`: An IDR Docker server
+  - `idr_vm_dockerworker`: An IDR Docker slave
+  - `idr_vm_bastion`: An IDR gateway host with external SSH
+  - `idr_vm_management`: An IDR monitoring server
+
 
 Advanced settings:
 - `idr_vm_groups`: A list of host-groups, default depends on the above booleans

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Optional variables:
 - `idr_vm_keyname`: Openstack SSH key, defaults to `idr-deployment-key` (see the `openstack-idr-keypairs` role)
 - `idr_vm_private_networks`: Use this network instead of the default one
 - `idr_vm_assign_floating_ip`: Assign a floating IP, default `False`
-- `idr_vm_count`: Number of VMs to create, default `1`. The first VM will be named `idr_vm_name`, subsequent VMs will be named `idr_vm_name-N`
+- `idr_vm_count`: Number of VMs to create, default `1` (named `idr_vm_name`).
+   If `idr_vm_count > 1` then all instances will be named with a numeric suffix `idr_vm_name-N`
 - `idr_vm_networks`: A list of `net-name: NETWORK_NAME` pairs
 
 Booleans indicating the purpose of this server:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,7 @@ idr_vm_count: 1
 # Booleans indicating the purpose of this server (multiple may be True)
 idr_vm_database: False
 idr_vm_omero: False
+idr_vm_omeroreadonly: False
 idr_vm_proxy: False
 idr_vm_dockermanager: False
 idr_vm_dockerworker: False
@@ -36,6 +37,7 @@ idr_vm_groups: >
   {{
     (idr_vm_database | ternary(idr_vm_default_groups_database, [])) +
     (idr_vm_omero | ternary(idr_vm_default_groups_omero, [])) +
+    (idr_vm_omeroreadonly | ternary(idr_vm_default_groups_omeroreadonly, [])) +
     (idr_vm_proxy | ternary(idr_vm_default_groups_proxy, [])) +
     (idr_vm_dockermanager | ternary(idr_vm_default_groups_dockermanager, [])) +
     (idr_vm_dockerworker | ternary(idr_vm_default_groups_dockerworker, [])) +
@@ -73,6 +75,13 @@ idr_vm_default_groups_database:
 idr_vm_default_groups_omero:
 - omero-hosts
 - "{{ idr_environment }}-omero-hosts"
+- "{{ idr_environment }}-hosts"
+
+idr_vm_default_groups_omeroreadonly:
+# Not sure about whether omeroreadonly should be part of omero
+#- omero-hosts
+- omeroreadonly-hosts
+- "{{ idr_environment }}-omeroreadonly-hosts"
 - "{{ idr_environment }}-hosts"
 
 idr_vm_default_groups_proxy:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,7 +51,7 @@ idr_vm_extra_groups: []
 idr_vm_security_groups: >
   {{
     ['default'] +
-    (idr_vm_omeroreadwrite | ternary(['idr-omeroreadwrite-external'], [])) +
+    (idr_vm_omeroreadwrite | ternary(['idr-omero-external'], [])) +
     (idr_vm_proxy | ternary(['idr-web-external'], [])) +
     (idr_vm_bastion | ternary(['idr-bastion-external'], [])) +
     (idr_vm_management | ternary(['idr-web-external'], []))

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,7 +24,7 @@ idr_vm_count: 1
 
 # Booleans indicating the purpose of this server (multiple may be True)
 idr_vm_database: False
-idr_vm_omero: False
+idr_vm_omeroreadwrite: False
 idr_vm_omeroreadonly: False
 idr_vm_proxy: False
 idr_vm_dockermanager: False
@@ -36,7 +36,7 @@ idr_vm_management: False
 idr_vm_groups: >
   {{
     (idr_vm_database | ternary(idr_vm_default_groups_database, [])) +
-    (idr_vm_omero | ternary(idr_vm_default_groups_omero, [])) +
+    (idr_vm_omeroreadwrite | ternary(idr_vm_default_groups_omeroreadwrite, [])) +
     (idr_vm_omeroreadonly | ternary(idr_vm_default_groups_omeroreadonly, [])) +
     (idr_vm_proxy | ternary(idr_vm_default_groups_proxy, [])) +
     (idr_vm_dockermanager | ternary(idr_vm_default_groups_dockermanager, [])) +
@@ -51,7 +51,7 @@ idr_vm_extra_groups: []
 idr_vm_security_groups: >
   {{
     ['default'] +
-    (idr_vm_omero | ternary(['idr-omero-external'], [])) +
+    (idr_vm_omeroreadwrite | ternary(['idr-omeroreadwrite-external'], [])) +
     (idr_vm_proxy | ternary(['idr-web-external'], [])) +
     (idr_vm_bastion | ternary(['idr-bastion-external'], [])) +
     (idr_vm_management | ternary(['idr-web-external'], []))
@@ -72,16 +72,18 @@ idr_vm_default_groups_database:
 - "{{ idr_environment }}-database-hosts"
 - "{{ idr_environment }}-hosts"
 
-idr_vm_default_groups_omero:
+idr_vm_default_groups_omeroreadwrite:
+- omeroreadwrite-hosts
+- "{{ idr_environment }}-omeroreadwrite-hosts"
 - omero-hosts
 - "{{ idr_environment }}-omero-hosts"
 - "{{ idr_environment }}-hosts"
 
 idr_vm_default_groups_omeroreadonly:
-# Not sure about whether omeroreadonly should be part of omero
-#- omero-hosts
 - omeroreadonly-hosts
 - "{{ idr_environment }}-omeroreadonly-hosts"
+- omero-hosts
+- "{{ idr_environment }}-omero-hosts"
 - "{{ idr_environment }}-hosts"
 
 idr_vm_default_groups_proxy:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   description: Create an Openstack VM for use with the IDR playbooks
   company: Open Microscopy Environment
   license: BSD
-  min_ansible_version: 2.1
+  min_ansible_version: 2.3
   platforms:
   - name: EL
     versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,8 +25,8 @@
 
 - name: idr vm | create VM
   os_server:
-    # Only add `-N` suffix for item>1
-    name: "{{ idr_vm_name }}{{ (item | int > 1) | ternary('-' + item, '') }}"
+    # Only add `-N` suffix for idr_vm_count>1
+    name: "{{ idr_vm_name }}{{ (idr_vm_count > 1) | ternary('-' + item, '') }}"
     state: present
     image: "{{ idr_vm_image }}"
     key_name: "{{ idr_vm_keyname }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
 - name: idr vm | get image
   os_image_facts:
     image: "{{ idr_vm_image }}"
-  always_run: yes
+  check_mode: no
   # Creates variable openstack_image
 
 - name: idr vm | check image

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
 - name: idr vm | check image
   fail:
     msg: "Openstack image {{ idr_vm_image }} not found"
-  when: "{{ not openstack_image }}"
+  when: "not openstack_image"
 
 - name: idr vm | create VM
   os_server:


### PR DESCRIPTION
This splits the `omero` group into separate `omeroreadwrite` and `omeroreadonly` groups.

This also changes the naming convention when `idr_vm_count > 1`. Previously the first VM would never have a numeric suffix, now it will have suffix `-1` if `idr_vm_count > 1`, and no suffix if `idr_vm_count == 1`.

This is a breaking change since the `idr_vm_omero` variable is now `idr_vm_omeroreadwrite`

Tag: `2.0.0`