### PR TITLE
Groups can be added as a second metadata property

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,6 @@
+# Changes in Version 3
+
+## Breaking changes
+
+- `idr_vm_extra_groups` is used to create a new openstack instance metadata property called `groups2` instead of being appended to `groups` to get around the 255 character limitation on property values.
+  If you are reading this property in a dynamic Ansible inventory script you will need to append the values from `groups2` to the list of Ansible groups taken from `groups`.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,7 +37,8 @@
       {{ dict([
           ("hostname", idr_vm_name),
           ("groups", ','.join(
-            idr_vm_groups + idr_vm_extra_groups + idr_vm_cloud_group)),
+            idr_vm_groups + idr_vm_cloud_group)),
+          ("groups2", ','.join(idr_vm_extra_groups)),
         ] +
         idr_vm_ssh_metadata +
         idr_vm_network_metadata


### PR DESCRIPTION
[Openstack limits property values to 255 chars](https://docs.openstack.org/api-ref/compute/?expanded=show-rate-and-absolute-limits-detail#servers-servers). Work around this by moving idr_vm_extra_groups into a second group property 'groups2' and appending this in the custom IDR ansible inventory script.

Tag: `3.0.0` since this is a breaking change that requires the openstack dynamic inventory script to be updated to match. The alternative is to add another property like `idr_vm_extra_groups2` but that might be more confusing. Any preference?