### PR TITLE
Set boot_from_volume to true for server creation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -127,3 +127,8 @@ idr_vm_cloud_group: >
     (idr_deployment_cloud | default('') | length > 0) | ternary(
       [idr_deployment_cloud + '-hosts'], [])
   }}
+
+# Compute the size of the boot volume from the flavor
+# Assumes VM flavor are following the <vcpus>c<ram>m<size>d scheme
+idr_vm_volume_size: >
+  {{ idr_vm_flavour | regex_findall('[0-9]+') | last | int }}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -127,8 +127,3 @@ idr_vm_cloud_group: >
     (idr_deployment_cloud | default('') | length > 0) | ternary(
       [idr_deployment_cloud + '-hosts'], [])
   }}
-
-# Compute the size of the boot volume from the flavor
-# Assumes VM flavor are following the <vcpus>c<ram>m<size>d scheme
-idr_vm_volume_size: >
-  {{ idr_vm_flavour | regex_findall('[0-9]+') | last | int }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,5 +44,8 @@
         idr_vm_network_metadata
       ) }}
     security_groups: "{{ idr_vm_security_groups | join(',') }}"
+    boot_from_volume: true
+    terminate_volume: true
+    volume_size: "{{ idr_vm_volume_size }}"
   register: vm
   with_sequence: "count={{ idr_vm_count }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,11 @@
     msg: "Openstack image {{ idr_vm_image }} not found"
   when: "not openstack_image"
 
+- name: idr vm | get volume size from flavor
+  os_flavor_facts:
+    name: "{{ idr_vm_flavour }}"
+  register: result
+
 - name: idr vm | create VM
   os_server:
     # Only add `-N` suffix for idr_vm_count>1
@@ -46,6 +51,6 @@
     security_groups: "{{ idr_vm_security_groups | join(',') }}"
     boot_from_volume: true
     terminate_volume: true
-    volume_size: "{{ idr_vm_volume_size }}"
+    volume_size: "{{ result.ansible_facts.openstack_flavors[0].disk }}"
   register: vm
   with_sequence: "count={{ idr_vm_count }}"


### PR DESCRIPTION
- Also terminate the volume with the VM deletion
- Compute the volume size from the VM flavor

See https://docs.embassy.ebi.ac.uk/userguide/Embassyv4.html#root-disks for the rationale behind this change. On Embassy Cloud v4, using ephemeral storage will lead to `No valid host was found` error during the `os_server` call. Setting `boot_from_volume: true` suffices to fix the issue. `terminate_volume: true` allows to delete the volume when deleting the server. This is necessary since the volume name cannot be controlled and prefixed with `idr_environment_idr`. Finally `volume_size` is computed from the VM flavor as per the new naming scheme.

If necessary, this behavior could be made optional using a boolean flag. However, for IDR, the new behavior will be the default for all VMs created on `uk1`. 

Tag: `3.2.0` or `4.0.0` if we consider this as a breaking change.