### PR TITLE
Create default group to reduce duplicates

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,7 +76,7 @@ idr_vm_network_metadata: >
   )] }}
 
 idr_vm_default_groups:
- - "{{ idr_environment }}-hosts"
+  - "{{ idr_environment }}-hosts"
 
 idr_vm_default_groups_database:
   - database-hosts

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,6 +35,7 @@ idr_vm_management: false
 # Default groups depend on the purpose of this server
 idr_vm_groups: >
   {{
+    idr_vm_default_groups +
     (idr_vm_database | ternary(idr_vm_default_groups_database, [])) +
     (idr_vm_omeroreadwrite | ternary(idr_vm_default_groups_omeroreadwrite,
      [])) +
@@ -74,47 +75,43 @@ idr_vm_network_metadata: >
        (idr_vm_networks | default([]) | map(attribute='net-name') | join(','))
   )] }}
 
+idr_vm_default_groups:
+ - "{{ idr_environment }}-hosts"
+
 idr_vm_default_groups_database:
   - database-hosts
   - "{{ idr_environment }}-database-hosts"
-  - "{{ idr_environment }}-hosts"
 
 idr_vm_default_groups_omeroreadwrite:
   - omeroreadwrite-hosts
   - "{{ idr_environment }}-omeroreadwrite-hosts"
   - omero-hosts
   - "{{ idr_environment }}-omero-hosts"
-  - "{{ idr_environment }}-hosts"
 
 idr_vm_default_groups_omeroreadonly:
   - omeroreadonly-hosts
   - "{{ idr_environment }}-omeroreadonly-hosts"
   - omero-hosts
   - "{{ idr_environment }}-omero-hosts"
-  - "{{ idr_environment }}-hosts"
 
 idr_vm_default_groups_proxy:
   - proxy-hosts
   - "{{ idr_environment }}-proxy-hosts"
-  - "{{ idr_environment }}-hosts"
 
 idr_vm_default_groups_bastion:
   - bastion-hosts
   - "{{ idr_environment }}-bastion-hosts"
-  - "{{ idr_environment }}-hosts"
 
 idr_vm_default_groups_dockermanager:
   - dockermanager-hosts
   - "{{ idr_environment }}-dockermanager-hosts"
   - "{{ idr_environment }}-docker-hosts"
-  - "{{ idr_environment }}-hosts"
   - "{{ idr_environment }}-data-hosts"
 
 idr_vm_default_groups_dockerworker:
   - dockerworker-hosts
   - "{{ idr_environment }}-dockerworker-hosts"
   - "{{ idr_environment }}-docker-hosts"
-  - "{{ idr_environment }}-hosts"
 
 # Management nodes are special since they may cross multiple environments
 idr_vm_default_groups_management:


### PR DESCRIPTION
Encountered as part of the deployment https://github.com/IDR/deployment/pull/367

When creating a pilot IDR server VM belonging to most groups (database, omero, docker), the current role will error due to the 255 characters limit of the instance metadata vaue e.g.

```
failed: [localhost] (item=1) => {"ansible_loop_var": "item", "changed": false, "extra_data": null, "item": "1", "msg": "BadRequestException: 400: Client Error for url: https://uk1.embassy.ebi.ac.uk:8774/v2.1/os-volumes_boot, Invalid input for field/attribute groups. Value: database-hosts,pilot-searchengine-database-hosts,pilot-searchengine-hosts,omeroreadwrite-hosts,pilot-searchengine-omeroreadwrite-hosts,omero-hosts,pilot-searchengine-omero-hosts,pilot-searchengine-hosts,dockermanager-hosts,pilot-searchengine-dockermanager-hosts,pilot-searchengine-docker-hosts,pilot-searchengine-hosts,pilot-searchengine-data-hosts,ebi-staging-hosts. 'database-hosts,pilot-searchengine-database-hosts,pilot-searchengine-hosts,omeroreadwrite-hosts,pilot-searchengine-omeroreadwrite-hosts,omero-hosts,pilot-searchengine-omero-hosts,pilot-searchengine-hosts,dockermanager-hosts,pilot-searchengine-dockermanager-hosts,pilot-searchengine-docker-hosts,pilot-searchengine-hosts,pilot-searchengine-data-hosts,ebi-staging-hosts' is too long"}
```

Looking at the content of the value, one immediate gain is that the `"{{ idr_environment }}-hosts"` value is replicated for each server group. This PR factors this value into a separate default group and fixes the immediate deployment issue.

This is primarily a quick workaround fix intended to be released as `3.1.2`. The instance might still fail to create for instance if the value of "{{ idr_environment }}" is too long.