### PR TITLE
Update role to consume openstack.cloud collection

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: ome/action-ome-ansible-molecule@main
         with:
           scenario: ${{ matrix.scenario }}
+          ome-ansible-molecule-version: 0.7.0a1
 
   publish:
     name: Galaxy

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Create an Openstack VM for use with the IDR playbooks
   company: Open Microscopy Environment
   license: BSD
-  min_ansible_version: 2.3
+  min_ansible_version: 2.10
   platforms:
     - name: EL
       versions:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,6 +1,8 @@
 ---
 dependency:
   name: galaxy
+  options:
+    requirements-file: requirements.yml
 driver:
   name: docker
 lint:

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,0 +1,4 @@
+---
+collections:
+ - src: openstack.cloud
+   version: 1.2.1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,23 +13,23 @@
 # https://github.com/ansible/ansible/pull/19653
 
 - name: idr vm | get image
-  os_image_facts:
+  openstack.cloud.image_info:
     image: "{{ idr_vm_image }}"
   check_mode: false
-  # Creates variable openstack_image
+  register: result
 
 - name: idr vm | check image
   fail:
     msg: "Openstack image {{ idr_vm_image }} not found"
-  when: "not openstack_image"
+  when: "not result.openstack_image"
 
 - name: idr vm | get volume size from flavor
-  os_flavor_facts:
+  openstack.cloud.compute_flavor_info:
     name: "{{ idr_vm_flavour }}"
   register: result
 
 - name: idr vm | create VM
-  os_server:
+  openstack.cloud.server:
     # Only add `-N` suffix for idr_vm_count>1
     name: "{{ idr_vm_name }}{{ (idr_vm_count > 1) | ternary('-' + item, '') }}"
     state: present
@@ -51,6 +51,6 @@
     security_groups: "{{ idr_vm_security_groups | join(',') }}"
     boot_from_volume: true
     terminate_volume: true
-    volume_size: "{{ result.ansible_facts.openstack_flavors[0].disk }}"
+    volume_size: "{{ result.openstack_flavors[0].disk }}"
   register: vm
   with_sequence: "count={{ idr_vm_count }}"


### PR DESCRIPTION
These are the minimal changes to this role required to use it together with Ansible 2.10. These changes were tested using  the `openstack.cloud` collection version 1.2.1 installed via `requirements.yml`

Overall, migrating towards the usage of collections feels reasonable wherever appropriate sense and in this case, it is a requirement to deploy environment using Ansible 2.10 and later.

Although the changes proposed here are functional, a more fundamental issue arises as roles cannot depend on collections and vice-versa. This is a limitation in place by design - see https://github.com/ansible/ansible/issues/76030 for more details.

Immediately, this discussion affects the Openstack roles which are the only ones that I needed to upgrade to consume collections, all the other OME roles worked fine with Ansible 2.10 in the context of IDR. I suspect the decisions to be made might be made while keeping the larger ecosystem of OME Ansible roles in mind especially if at some point we decide we want to consume collections like `community.postgresql`.

Without too much thinking, I see two options to move forward:

- deprecate these roles and migrate their logic into an IDR collection for the Openstack deployment e.g. `idr.openstack`. This collection can depend on `openstack.cloud` and be declared as a dependency of IDR/deployment
- move these roles back to https://github.com/IDR/deployment and effectively turn this repository into a collection in the end

/cc @pwalczysko @jburel 